### PR TITLE
set evaluation_result_detail weight to zero if no evaluations applicable

### DIFF
--- a/src/services/evaluation-result-detail-service.ts
+++ b/src/services/evaluation-result-detail-service.ts
@@ -56,7 +56,7 @@ export const calculateScore = async (evaluation_result_id: number) => {
     const isAllNa =
       allAnswerTypes.length > 0 ? allAnswerTypes.every((answer) => answer === AnswerType.NA) : false
 
-    if (isAllNa) {
+    if (isAllNa || evaluations.length === 0) {
       await EvaluationResultDetailRepository.updateWeightById(evaluationResultDetail.id, 0)
     }
 


### PR DESCRIPTION
Ticket ID: [Evaluation Form - if sum of weight of all evaluations for a particular template is 0, then set the corresponding score and weight of evaluation_result_details for that template to 0 also. #175](https://github.com/nerubia/kh360-nodejs/issues/175)
