### PR TITLE
add max limit to characters for project and eval admin names

### DIFF
--- a/src/utils/validation/evaluation-administration-schema.ts
+++ b/src/utils/validation/evaluation-administration-schema.ts
@@ -1,7 +1,7 @@
 import { array, object, string } from "yup"
 
 export const createEvaluationAdministrationSchema = object().shape({
-  name: string().required("Name is required"),
+  name: string().required("Name is required").max(100, "Name must be at most 100 characters"),
   eval_period_start_date: string()
     .required("Start period is required")
     .test("start-date", "Start period must be before end period", function (start_date) {

--- a/src/utils/validation/project-schema.ts
+++ b/src/utils/validation/project-schema.ts
@@ -1,7 +1,7 @@
 import { number, object, string } from "yup"
 
 export const createProjectSchema = object().shape({
-  name: string().required("Name is required"),
+  name: string().required("Name is required").max(255, "Name must be at most 255 characters"),
   client_id: number().optional(),
   start_date: string().test(
     "start_date",


### PR DESCRIPTION
Ticket IDs:
- [Create Evaluation - 500 error when saving evaluation with 574 inputted characters in Evaluation Name field #710](https://github.com/nerubia/kh360-react/issues/710)
- [Edit Project - Something went wrong or error 500 after I clicked save button #705](https://github.com/nerubia/kh360-react/issues/705)

FE PR: [add max limit to characters for project and eval admin names #715](https://github.com/nerubia/kh360-react/pull/715)
