### PR TITLE
fix bug on batch process for closing eval admin

### DIFF
--- a/src/services/evaluation-result-detail-service.ts
+++ b/src/services/evaluation-result-detail-service.ts
@@ -45,7 +45,9 @@ export const calculateScore = async (evaluation_result_id: number) => {
       const evaluationRatings = await EvaluationRatingRepository.getAllByFilters({
         evaluation_id: evaluation.id,
       })
-      const answerOptionIds = evaluationRatings.map((answer) => answer.answer_option_id)
+      const answerOptionIds = evaluationRatings
+        .map((answer) => answer.answer_option_id)
+        .filter((id) => id !== null)
       const answerOptions = await AnswerOptionRepository.getAllByFilters({
         id: {
           in: answerOptionIds as number[],


### PR DESCRIPTION
Ticket ID: [Create batch process to close Evaluation Administration after end of evaluation period #492](https://github.com/nerubia/kh360-nodejs/issues/492#issuecomment-1982660140)

Reason: Evaluation admin was closed but evaluations were not answered or fully submitted yet, therefore resulted in an error because answer options were null.
