### PR TITLE
node-1112-nudge-or-reminder-no-validation-display-for-empty-template

### DIFF
--- a/src/controllers/admin/evaluation-administration-controller.ts
+++ b/src/controllers/admin/evaluation-administration-controller.ts
@@ -552,6 +552,9 @@ export const sendReminder = async (req: Request, res: Response) => {
     )
     res.json({ evaluatorId: user_id, emailLog })
   } catch (error) {
+    if (error instanceof CustomError) {
+      return res.status(error.status).json({ message: error.message })
+    }
     res.status(500).json({ message: "Something went wrong" })
   }
 }


### PR DESCRIPTION
Ticket ID:
Nudge or Reminder - No validation display for empty default from message template
[#1112](https://github.com/nerubia/kh360-react/issues/1112)
FE: https://github.com/nerubia/kh360-react/pull/1147